### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.2"
 edition = "2021"
 description = "A Rust lib for general code file relationship analysis. Based on tree-sitter and git analysis."
 license = "Apache-2.0"
-homepage = "https://github.com/williamfzc/gossiphs"
+repository = "https://github.com/williamfzc/gossiphs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.